### PR TITLE
various improvements to daemonization and readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Makefile
 Makefile.old
 pm_to_blib
 MYMETA.*
+Qmail-Deliverable-*.tar.gz

--- a/Changes.md
+++ b/Changes.md
@@ -2,79 +2,89 @@
 
 Revision history for the `Qmail::Deliverable` Perl extension.
 
+## 1.11
+
+- new: `Qmail::Deliverable::Status` module exporting symbolic constants (`QD_DELIVERABLE`, ...) for the 16 status codes
+- fix: sticky-bit homedir check (status `0x22`) used `-T _`  where it should have been `-k _`; the check is now reachable
+- change: `qmail-deliverabled` now performs proper daemonization with `POSIX::setsid`; binds the listen socket before forking so port-bind errors are visible
+- change: `qmail-deliverabled` installs SIGTERM/SIGINT handlers for clean shutdown, removes the pidfile on exit
+- change: `qmail-deliverabled` ignores SIGPIPE so a broken client mid-response does not kill the daemon
+- change: removed the deprecated old-style positional argv parsing in `qmail-deliverabled` (deprecated since 1.04, ~2007)
+
+
 ## 1.10
 
-- **new:** a raft of new tests focusing on end-to-end behavior
-- **change:** docs are now in markdown format
+- new: a raft of new tests focusing on end-to-end behavior
+- change: docs are now in markdown format
 - updated attribution for contributors
 
 ## 1.09
 
-- **new:** detect ezmlm lists, reject null senders to lists
-- **new:** correctly ignore comments in `qmail/users/assign` (#3)
-- **new:** add module syntax tests (#3)
-- **new:** add regression test that exercises bug reported in #2
-- **fix:** fix interpretation of wildcard assignments (#2)
+- new: detect ezmlm lists, reject null senders to lists
+- new: correctly ignore comments in `qmail/users/assign` (#3)
+- new: add module syntax tests (#3)
+- new: add regression test that exercises bug reported in #2
+- fix: fix interpretation of wildcard assignments (#2)
 - Contributors: Martin Sluka, Matt Simerson
 
 ## 1.08
 
-- **change:** License change only.
+- change: License change only.
 
 ## 1.07
 
-- **fix:** `default@example.org` in `vpopmail/valias` now works as intended.
-- **new:** Support for vpopmail user-ext (disabled by default).
-- **change:** The plugin `check_qmail_deliverable` lost its `check_` prefix.
+- fix: `default@example.org` in `vpopmail/valias` now works as intended.
+- new: Support for vpopmail user-ext (disabled by default).
+- change: The plugin `check_qmail_deliverable` lost its `check_` prefix.
 - Contributor: Matt Simerson
 
 ## 1.06
 
-- **new:** Support for vpopmail `vaddaliasdomain`.
+- new: Support for vpopmail `vaddaliasdomain`.
 
 ## 1.05
 
-- **new:** Support for vpopmail valias address extensions (`foo-default`).
+- new: Support for vpopmail valias address extensions (`foo-default`).
 
 ## 1.04
 
-- **new:** Support for vpopmail valias addresses.
-- **new:** Support for vpopmail "big dir" (hashed directory structure).
-- **change:** `qmail-deliverabled` now uses GNU-style long options; old-style
+- new: Support for vpopmail valias addresses.
+- new: Support for vpopmail "big dir" (hashed directory structure).
+- change: `qmail-deliverabled` now uses GNU-style long options; old-style
   argument passing is deprecated.
-- **new:** `qmail-deliverabled` can now stay in the foreground for use with
+- new: `qmail-deliverabled` can now stay in the foreground for use with
   DJB's daemontools.
-- **security:** Made `qmail-deliverabled` safer and taint-mode compliant for
+- security: Made `qmail-deliverabled` safer and taint-mode compliant for
   Perl 5.10.
 
 ## 1.03
 
-- **new:** `qmail-deliverabled` now takes a pidfile on the command line, and
+- new: `qmail-deliverabled` now takes a pidfile on the command line, and
   can stop itself using that.
-- **docs:** `Qmail::Deliverable::Comparison`, a document to compare with other
+- docs: `Qmail::Deliverable::Comparison`, a document to compare with other
   qmail deliverability checkers.
-- **fix:** Now correctly loads `me` if `locals` does not exist.
-- **new:** An example init.d script.
+- fix: Now correctly loads `me` if `locals` does not exist.
+- new: An example init.d script.
 
 ## 1.02
 
-- **new:** Support for `bouncesaying`, although without using the configured
+- new: Support for `bouncesaying`, although without using the configured
   error message. Plesk puts `|bouncesaying` in `.qmail-default`.
 
 ## 1.01
 
-- **change:** qpsmtpd plugin `check_qmail_deliverable` installs as a binary,
+- change: qpsmtpd plugin `check_qmail_deliverable` installs as a binary,
   so that it has a manpage. If you execute it, you get installation
   instructions.
-- **new:** `$Qmail::Deliverable::Client::SERVER` can be a callback now.
-- **change:** Plugin now uses the callback option for cleaner code.
-- **fix:** Plugin now allows hostnames instead of IP addresses only.
-- **fix:** Exclusions now enabled for smtproutes.
-- **incompatible:** `::Client::qmail_local` no longer returns `undef` on
+- new: `$Qmail::Deliverable::Client::SERVER` can be a callback now.
+- change: Plugin now uses the callback option for cleaner code.
+- fix: Plugin now allows hostnames instead of IP addresses only.
+- fix: Exclusions now enabled for smtproutes.
+- incompatible: `::Client::qmail_local` no longer returns `undef` on
   connection error, because `undef` already meant something else.
-- **new:** `qmail-deliverabled` has basic statistics in `$0`.
-- **docs:** Minor documentation updates.
+- new: `qmail-deliverabled` has basic statistics in `$0`.
+- docs: Minor documentation updates.
 
 ## 1.00
 
-- **new:** First CPAN release.
+- new: First CPAN release.

--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,7 @@ Revision history for the `Qmail::Deliverable` Perl extension.
 - change: `qmail-deliverabled` installs SIGTERM/SIGINT handlers for clean shutdown, removes the pidfile on exit
 - change: `qmail-deliverabled` ignores SIGPIPE so a broken client mid-response does not kill the daemon
 - change: removed the deprecated old-style positional argv parsing in `qmail-deliverabled` (deprecated since 1.04, ~2007)
-
+- docs: added signal handling details for SIGHUP, SIGTERM, and SIGINT
 
 ## 1.10
 
@@ -50,32 +50,25 @@ Revision history for the `Qmail::Deliverable` Perl extension.
 
 - new: Support for vpopmail valias addresses.
 - new: Support for vpopmail "big dir" (hashed directory structure).
-- change: `qmail-deliverabled` now uses GNU-style long options; old-style
-  argument passing is deprecated.
-- new: `qmail-deliverabled` can now stay in the foreground for use with
-  DJB's daemontools.
+- change: `qmail-deliverabled` now uses GNU-style long options; old-style argument passing is deprecated.
+- new: `qmail-deliverabled` can now stay in the foreground for use with DJB's daemontools.
 - security: Made `qmail-deliverabled` safer and taint-mode compliant for
   Perl 5.10.
 
 ## 1.03
 
-- new: `qmail-deliverabled` now takes a pidfile on the command line, and
-  can stop itself using that.
-- docs: `Qmail::Deliverable::Comparison`, a document to compare with other
-  qmail deliverability checkers.
+- new: `qmail-deliverabled` now takes a pidfile on the command line, and can stop itself using that.
+- docs: `Qmail::Deliverable::Comparison`, a document to compare with other qmail deliverability checkers.
 - fix: Now correctly loads `me` if `locals` does not exist.
 - new: An example init.d script.
 
 ## 1.02
 
-- new: Support for `bouncesaying`, although without using the configured
-  error message. Plesk puts `|bouncesaying` in `.qmail-default`.
+- new: Support for `bouncesaying`, although without using the configured error message. Plesk puts `|bouncesaying` in `.qmail-default`.
 
 ## 1.01
 
-- change: qpsmtpd plugin `check_qmail_deliverable` installs as a binary,
-  so that it has a manpage. If you execute it, you get installation
-  instructions.
+- change: qpsmtpd plugin `check_qmail_deliverable` installs as a binary, so that it has a manpage. If you execute it, you get installation instructions.
 - new: `$Qmail::Deliverable::Client::SERVER` can be a callback now.
 - change: Plugin now uses the callback option for cleaner code.
 - fix: Plugin now allows hostnames instead of IP addresses only.

--- a/MANIFEST
+++ b/MANIFEST
@@ -4,6 +4,7 @@ init.d/qmail-deliverabled
 lib/Qmail/Deliverable.pm
 lib/Qmail/Deliverable/Client.pm
 lib/Qmail/Deliverable/Comparison.pod
+lib/Qmail/Deliverable/Status.pm
 Makefile.PL
 MANIFEST
 META.yml
@@ -11,11 +12,13 @@ qpsmtpd-plugin/qmail_deliverable
 README.md
 t/00.syntax.t
 t/10.helpers.t
+t/15.constants.t
 t/20.qmail_local.t
 t/30.qmail_user.t
 t/40.dot_qmail.t
 t/50.deliverable.t
 t/60.daemon.t
+t/65.daemon_signals.t
 t/70.client.t
 t/80.qpsmtpd_plugin.t
 t/Qmail-Deliverable.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,7 @@ lib/Qmail/Deliverable/Comparison.pod
 lib/Qmail/Deliverable/Status.pm
 Makefile.PL
 MANIFEST
+MANIFEST.SKIP
 META.yml
 qpsmtpd-plugin/qmail_deliverable
 README.md

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,2 +1,4 @@
 .claude
-Qmail-Deliverable-*.tar.gz
+.git
+Qmail-Deliverable-?.??.tar.gz
+cover_db

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,4 +1,4 @@
 .claude
 .git
-Qmail-Deliverable-?.??.tar.gz
+^Qmail-Deliverable-\d+\.\d+\.tar(?:\.gz)?$
 cover_db

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,2 @@
+.claude
+Qmail-Deliverable-*.tar.gz

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,4 +1,4 @@
-.claude
-.git
+^\.claude
+^\.git
 ^Qmail-Deliverable-\d+\.\d+\.tar(?:\.gz)?$
-cover_db
+^cover_db

--- a/META.yml
+++ b/META.yml
@@ -1,6 +1,6 @@
 --- #YAML:1.0
 name:                Qmail-Deliverable
-version:             1.10
+version:             1.11
 abstract:            Determine deliverability of local addresses
 license:             ~
 author:              

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,11 @@ my @authors = (
     'Martin Sluka',
 );
 
+my %dist = ();
+if ( $^O eq 'darwin' ) {
+    $dist{TAR} = 'COPY_EXTENDED_ATTRIBUTES_DISABLE=1 COPYFILE_DISABLE=1 tar';
+}
+
 WriteMakefile(
     NAME              => 'Qmail::Deliverable',
     VERSION_FROM      => 'lib/Qmail/Deliverable.pm', # finds $VERSION
@@ -43,4 +48,5 @@ WriteMakefile(
         },
         x_contributors => [ 'Martin Sluka' ],
     },
+    dist => \%dist,
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,6 @@ WriteMakefile(
     VERSION_FROM      => 'lib/Qmail/Deliverable.pm', # finds $VERSION
     ABSTRACT_FROM     => 'lib/Qmail/Deliverable.pm', # retrieve abstract from module
     AUTHOR            => 'Matt Simerson <msimerson@cpan.org>',
-    LICENSE           => 'perl_5',
     MIN_PERL_VERSION  => '5.006',
     EXE_FILES         => [ 'bin/qmail-deliverabled', 'qpsmtpd-plugin/qmail_deliverable' ],
     PREREQ_PM         => {},

--- a/bin/qmail-deliverabled
+++ b/bin/qmail-deliverabled
@@ -3,28 +3,23 @@ use strict;
 
 use HTTP::Daemon;
 use HTTP::Status;
+use POSIX ();
 use URI::Escape qw(uri_unescape);
 use Qmail::Deliverable ':all';
 use Getopt::Long;
 Getopt::Long::Configure("bundling");
 
-my ($listen, $pidfile, $verbose, $stop, $foreground);
-$listen = "127.0.0.1:8998";
+my ($pidfile, $verbose, $stop, $foreground);
+my $listen = "127.0.0.1:8998";
 
-if (@ARGV and $ARGV[0] !~ /^-/) {
-    warn "WARNING: Using deprecated old style command line argument parsing. Update your startup scripts!\n";
-
-    ($listen, $pidfile) = @ARGV;
-} else {
-    GetOptions(
-        "help|h"       => sub { die "Use 'man qmail-deliverabled' for full documentation.\n" },
-        "verbose|v"    => \$verbose,
-        "listen|l=s"   => \$listen,
-        "pidfile|p:s"  => \$pidfile,
-        "stop"         => \$stop,
-        "foreground|f" => \$foreground,
-    ) or exit 255;
-}
+GetOptions(
+    "help|h"       => sub { die "Use 'man qmail-deliverabled' for full documentation.\n" },
+    "verbose|v"    => \$verbose,
+    "listen|l=s"   => \$listen,
+    "pidfile|p:s"  => \$pidfile,
+    "stop"         => \$stop,
+    "foreground|f" => \$foreground,
+) or exit 255;
 
 ($listen) = $listen =~ /^(stop|[0-9.]+:[0-9]+)$/
     or die "Listen argument must be ip:port!\n";
@@ -50,27 +45,42 @@ if ($stop or $listen eq 'stop') {
     exit;
 }
 
-
-fork && exit unless $foreground;
-
-$verbose && print "My PID is $$.\n";
-
+# Bind the listener before daemonizing so any "address already in use"
+# error surfaces in the foreground where the operator can see it.
 my $d = HTTP::Daemon->new(
     LocalAddr => $listen,
     ReuseAddr => 1,
-) or die "Could not start daemon ($!)";
+) or die "Could not start daemon ($!)\n";
 
-if ($pidfile) {
-    open my $fh, '>', $pidfile or die "Could not open pidfile $pidfile: $!\n";
-    print { $fh } $$;
-    close $fh or die "Could not write to pidfile $pidfile: $!\n";
+daemonize() unless $foreground;
+
+# pidfile is written AFTER daemonization so it records the final PID.
+# Only the surviving (grand)child reaches this point.
+my $cleanup_pidfile;
+END {
+    unlink $cleanup_pidfile
+        if defined $cleanup_pidfile && -e $cleanup_pidfile;
 }
 
-$SIG{HUP} = sub {
+if ($pidfile) {
+    open my $fh, '>', $pidfile
+        or die "Could not open pidfile $pidfile: $!\n";
+    print { $fh } $$
+        or die "Could not write to pidfile $pidfile: $!\n";
+    close $fh
+        or die "Could not close pidfile $pidfile: $!\n";
+    $cleanup_pidfile = $pidfile;
+}
+
+$SIG{TERM} = $SIG{INT} = sub { exit 0 };
+$SIG{HUP}  = sub {
     warn "SIGHUP received.\n";
     reread_config;
     warn "Qmail configuration reloaded.\n";
 };
+$SIG{PIPE} = 'IGNORE';  # broken client mid-response should not kill us
+
+$verbose && print "My PID is $$.\n";
 
 my ($base0) = $0 =~ /([\x20-\x7f]+)/;
 my %counter;
@@ -84,7 +94,8 @@ for (;;) {
         $verbose && printf "Accepted request from %vd.\n", $c->peeraddr;
         while (my $r = $c->get_request) {
             if ($r->method ne 'GET' or $r->uri->path !~ m[^/qd1/]) {
-                $verbose && printf "Not a qd request: %s %s\n", $r->method, $r->uri->path;
+                $verbose && printf "Not a qd request: %s %s\n",
+                                   $r->method, $r->uri->path;
                 $c->send_error(RC_FORBIDDEN);
                 next;
             }
@@ -107,30 +118,50 @@ for (;;) {
                 $verbose && printf "deliverable('%s') => ", $arg;
                 $rv = eval { deliverable($arg) };
                 $verbose && printf "0x%02x\n", $rv;
-                $counter{yes}++ if $rv;
-                $counter{no}++ if not $rv;
+                $counter{yes}++ if   $rv;
+                $counter{no}++  if ! $rv;
                 my $total = $counter{yes} + $counter{no};
                 $0 = sprintf "$base0 yes=%d(%.1f%%), no=%d(%.1f%%), total=%d",
                     $counter{yes}, $counter{yes}/$total*100,
                     $counter{no},  $counter{no} /$total*100,
                     $total;
-
             } else {
-                $verbose && print "Unknown command: %s\n", $command;
+                $verbose && printf "Unknown command: %s\n", $command;
                 $c->send_error(RC_FORBIDDEN);
                 next;
             }
             if (defined $rv) {
-                $c->send_response( HTTP::Response->new(200, "OK", undef, $rv) );
+                $c->send_response(
+                    HTTP::Response->new(200, "OK", undef, $rv));
             } else {
-                $c->send_response( HTTP::Response->new(204, "UNDEF", undef, "undef") );
+                $c->send_response(
+                    HTTP::Response->new(204, "UNDEF", undef, "undef"));
             }
-
         }
         $c->close;
         undef($c);
     }
     sleep 5;
+}
+
+# Standard double-fork daemonization: detaches from the controlling terminal,
+# becomes its own session leader, and redirects standard handles to /dev/null
+# so output from libraries doesn't end up on a terminal that no longer cares.
+sub daemonize {
+    my $pid = fork;
+    die "fork: $!\n" if not defined $pid;
+    exit 0 if $pid;             # original parent exits
+
+    POSIX::setsid() != -1 or die "setsid: $!\n";
+
+    $pid = fork;
+    die "fork: $!\n" if not defined $pid;
+    exit 0 if $pid;             # session leader exits
+
+    open STDIN,  '<', '/dev/null' or die "reopen STDIN: $!\n";
+    open STDOUT, '>', '/dev/null' or die "reopen STDOUT: $!\n";
+    open STDERR, '>', '/dev/null' or die "reopen STDERR: $!\n";
+    umask 0;
 }
 
 __END__
@@ -164,13 +195,30 @@ any error.
 A simple init.d-style script is provided in the .tar.gz, in the init.d
 directory.
 
+=head1 SIGNALS
+
+=over 4
+
+=item SIGHUP
+
+Re-read C</var/qmail/control/locals>, C</var/qmail/control/virtualdomains>,
+and C</var/qmail/users/assign> without restarting.
+
+=item SIGTERM, SIGINT
+
+Shut down cleanly. The pidfile (if any) is removed before exit.
+
+=back
+
 =head1 CAVEATS
 
 The PIDFILE is not used to avoid concurrent processes: it's perfectly fine to
 have multiple qmail-deliverableds running on different addresses or ports, but
 make sure each combination has its own PIDFILE.
 
-Verbose mode may get messy.
+Verbose mode is only useful when also running with C<--foreground>; once
+daemonized, standard handles are redirected to /dev/null and verbose output
+is silently discarded.
 
 =head1 LEGAL
 

--- a/lib/Qmail/Deliverable.pm
+++ b/lib/Qmail/Deliverable.pm
@@ -4,10 +4,17 @@ use strict;
 use 5.006;
 use Carp qw(carp);
 use base 'Exporter';
+use Qmail::Deliverable::Status qw(:status);
 
 our $VERSION = '1.10';
-our @EXPORT_OK = qw/reread_config qmail_local dot_qmail deliverable qmail_user/;
-our %EXPORT_TAGS = (all => \@EXPORT_OK);
+our @EXPORT_OK = (
+    qw(reread_config qmail_local dot_qmail deliverable qmail_user),
+    @Qmail::Deliverable::Status::STATUS,
+);
+our %EXPORT_TAGS = (
+    all    => \@EXPORT_OK,
+    status => \@Qmail::Deliverable::Status::STATUS,
+);
 our $VPOPMAIL_EXT = 0;
 our $qmail_dir = '/var/qmail';
 
@@ -242,30 +249,30 @@ sub deliverable {
         or do { carp "Invalid address: $in"; return; };
 
     my $local = qmail_local $address;
-    return 0xff if not defined $local;
+    return QD_NOT_LOCAL if not defined $local;
 
     my ($user, $uid, $gid, $homedir, $dash, $ext) = qmail_user $local;
 
-    return 0x11 if not -r $homedir or not -x _;
-    return 0x21 if (stat _)[2] & 0020;  # group writable
-    return 0x21 if (stat _)[2] & 0002;  # world writable
-    return 0x22 if -T _;
+    return QD_UNKNOWN_PERM_DENIED     if not -r $homedir or not -x _;
+    return QD_TEMPFAIL_GROUP_WRITABLE if (stat _)[2] & 0020;
+    return QD_TEMPFAIL_GROUP_WRITABLE if (stat _)[2] & 0002;
+    return QD_TEMPFAIL_STICKY         if -k _;
 
     my $dot_qmail = dot_qmail $user, $uid, $gid, $homedir, $dash, $ext;
 
-    return 0x00 if not defined $dot_qmail;
-    return 0xf1 if not length $dot_qmail;  # no .qmail => defaultdelivery
+    return QD_NOT_DELIVERABLE if not defined $dot_qmail;
+    return QD_DELIVERABLE     if not length $dot_qmail;  # defaultdelivery
 
-    return 0x00 if not -e $dot_qmail;
-    return 0x11 if not -r $dot_qmail;
-    return 0xf1 if not -s _;  # empty => defaultdelivery
+    return QD_NOT_DELIVERABLE     if not -e $dot_qmail;
+    return QD_UNKNOWN_PERM_DENIED if not -r $dot_qmail;
+    return QD_DELIVERABLE         if not -s _;           # empty => defaultdelivery
 
     my @dot_qmail = _slurp $dot_qmail;
 
     if ($dot_qmail[0] =~ /^\|\s*\S*vdelivermail/) {
         if ($address !~ /\@/) {
             carp "vpopmail support not available if no domain given";
-            return 0xfe;
+            return QD_VPOPMAIL_NO_DOMAIN;
         }
         my $origlocal = (split /\@/, $address)[0];
 
@@ -275,30 +282,31 @@ sub deliverable {
         $address = $origlocal . '@' . $user;
 
         if ($dot_qmail[0] =~ /bounce-no-mailbox/) {
-            return 0xf2 if -d "$homedir/$origlocal";
-            return 0xf3 if valias $address;
-            return 0xf5 if vuser $address;
-            if ( $VPOPMAIL_EXT ) {
+            return QD_VPOPMAIL_DIR    if -d "$homedir/$origlocal";
+            return QD_VPOPMAIL_VALIAS if valias $address;
+            return QD_VPOPMAIL_VUSER  if vuser $address;
+            if ($VPOPMAIL_EXT) {
                 my ($local, $domain) = split /@/, $address;
-                my @chunks = split /\-/, $local; # vpopmails qmail-ext option
-                for ( 0 .. $#chunks ) {
-                    return 0xf6 if vuser $chunks[$_] .'@'.$domain;
-                };
-            };
-            return 0x00;
+                my @chunks = split /\-/, $local;  # vpopmail qmail-ext option
+                for (0 .. $#chunks) {
+                    return QD_VPOPMAIL_QMAIL_EXT
+                        if vuser $chunks[$_] . '@' . $domain;
+                }
+            }
+            return QD_NOT_DELIVERABLE;
         }
-        return 0xf4;
+        return QD_VPOPMAIL_CATCHALL;
     }
     if ($dot_qmail[0] =~ /^\|bouncesaying\s+(.*)/) {
         my @args = $1 =~ /$shell_token/g;
-        return 0x13 if @args > 1;
-        return 0x00;
+        return QD_UNKNOWN_BOUNCESAYING if @args > 1;
+        return QD_NOT_DELIVERABLE;
     }
 
-    return 0x14 if grep /ezmlm/, @dot_qmail;
-    return 0x12 if grep /^\|/, @dot_qmail;
+    return QD_EZMLM        if grep /ezmlm/, @dot_qmail;
+    return QD_UNKNOWN_PIPE if grep /^\|/, @dot_qmail;
 
-    return 0xf1;
+    return QD_DELIVERABLE;
 }
 
 reread_config;
@@ -350,7 +358,8 @@ user, and the client is used by the unprivileged smtpd.
 =head2 Functions
 
 All documented functions are exportable, and a tag :all is available for
-convenience.
+convenience. Status-code constants (see L</Status codes>) are exported via
+the C<:status> tag, and are also included in C<:all>.
 
 Note that addresses and local user names must be in user@domain form, just like
 qmail internally uses. Comments, angle brackets, etcetera, must be stripped
@@ -401,27 +410,28 @@ if deliverability could not be determined.
 The system default delivery method, and mailbox, maildir, and forward
 instructions in dot-qmail files, are assumed to always succeed.
 
-Possible return values are:
+Possible return values (with the constant name from
+L<Qmail::Deliverable::Status>):
 
-    0x00   Not deliverable
+    0x00   QD_NOT_DELIVERABLE          Not deliverable
 
-    0x11   Deliverability unknown: permission denied for any file
-    0x12   Deliverability unknown: qmail-command called in dot-qmail file
-    0x13   Deliverability unknown: bouncesaying with program
-    0x14   Deliverable, probable:  ezmlm mailing list
+    0x11   QD_UNKNOWN_PERM_DENIED      Deliverability unknown: permission denied
+    0x12   QD_UNKNOWN_PIPE             Deliverability unknown: qmail-command
+    0x13   QD_UNKNOWN_BOUNCESAYING     Deliverability unknown: bouncesaying with program
+    0x14   QD_EZMLM                    Deliverable, probable: ezmlm mailing list
 
-    0x21   Temporarily undeliverable: group/world writable
-    0x22   Temporarily undeliverable: homedir is sticky
+    0x21   QD_TEMPFAIL_GROUP_WRITABLE  Temporarily undeliverable: group/world writable
+    0x22   QD_TEMPFAIL_STICKY          Temporarily undeliverable: homedir is sticky
 
-    0xf1   Deliverable, almost certainly
-    0xf2   Deliverable, vdelivermail: directory exists
-    0xf3   Deliverable, vdelivermail: valias exists
-    0xf4   Deliverable, vdelivermail: catch-all defined
-    0xf5   Deliverable, vdelivermail: vuser exists
-    0xf6   Deliverable, vdelivermail: qmail-ext
+    0xf1   QD_DELIVERABLE              Deliverable, almost certainly
+    0xf2   QD_VPOPMAIL_DIR             vdelivermail: directory exists
+    0xf3   QD_VPOPMAIL_VALIAS          vdelivermail: valias exists
+    0xf4   QD_VPOPMAIL_CATCHALL        vdelivermail: catch-all defined
+    0xf5   QD_VPOPMAIL_VUSER           vdelivermail: vuser exists
+    0xf6   QD_VPOPMAIL_QMAIL_EXT       vdelivermail: qmail-ext
 
-    0xfe   vpopmail (vdelivermail) detected but no domain was given
-    0xff   Domain is not local
+    0xfe   QD_VPOPMAIL_NO_DOMAIN       vpopmail detected but no domain was given
+    0xff   QD_NOT_LOCAL                Domain is not local
 
 (These values are, currently, not bitmasks. Do not treat them as such.)
 
@@ -446,6 +456,22 @@ Re-reads the config files /var/qmail/control/locals,
 /var/qmail/control/virtualdomains, and /var/qmail/users/assign.
 
 =back
+
+=head2 Status codes
+
+The numeric values returned by C<deliverable> have symbolic constants
+defined in L<Qmail::Deliverable::Status> and re-exported by this module
+under the C<:status> tag:
+
+    use Qmail::Deliverable qw(deliverable :status);
+
+    my $rv = deliverable $address;
+    return DECLINED if $rv == QD_DELIVERABLE;
+    return DENY     if $rv == QD_NOT_DELIVERABLE;
+
+See L<Qmail::Deliverable::Status> for the full list. Numeric values are
+unchanged from earlier releases, so the constants are a drop-in
+readability improvement.
 
 =head1 CAVEATS
 

--- a/lib/Qmail/Deliverable.pm
+++ b/lib/Qmail/Deliverable.pm
@@ -6,7 +6,7 @@ use Carp qw(carp);
 use base 'Exporter';
 use Qmail::Deliverable::Status qw(:status);
 
-our $VERSION = '1.10';
+our $VERSION = '1.11';
 our @EXPORT_OK = (
     qw(reread_config qmail_local dot_qmail deliverable qmail_user),
     @Qmail::Deliverable::Status::STATUS,

--- a/lib/Qmail/Deliverable/Client.pm
+++ b/lib/Qmail/Deliverable/Client.pm
@@ -6,9 +6,16 @@ use Carp qw(carp);
 use base 'Exporter';
 use LWP::Simple qw($ua);
 use URI::Escape qw(uri_escape);
+use Qmail::Deliverable::Status qw(:status);
 
-our @EXPORT_OK = qw/qmail_local deliverable/;
-our %EXPORT_TAGS = (all => \@EXPORT_OK);
+our @EXPORT_OK = (
+    qw(qmail_local deliverable),
+    @Qmail::Deliverable::Status::STATUS,
+);
+our %EXPORT_TAGS = (
+    all    => \@EXPORT_OK,
+    status => \@Qmail::Deliverable::Status::STATUS,
+);
 
 our $SERVER = "127.0.0.1:8998";
 our $ERROR;
@@ -64,9 +71,9 @@ sub deliverable {
         or do { carp "Invalid address: $in"; return; };
 
     my $rv = _remote 'deliverable', $address;
-    return 0x2f if not defined $rv;  # shouldn't happen
-    return 0x2f if not length $rv;   # shouldn't happen
-    return 0x2f if $rv eq "\0";
+    return QD_CLIENT_FAILURE if not defined $rv;  # shouldn't happen
+    return QD_CLIENT_FAILURE if not length $rv;   # shouldn't happen
+    return QD_CLIENT_FAILURE if $rv eq "\0";
 
     return $rv;
 }
@@ -135,10 +142,21 @@ failure.
 
 =item deliverable $local
 
-As Qmail::Deliverable::deliverable. Warns and returns 0x2f on communication
-failure.
+As Qmail::Deliverable::deliverable. Warns and returns
+C<QD_CLIENT_FAILURE> (0x2f) on communication failure.
 
 =back
+
+=head2 Status codes
+
+Status-code constants are re-exported under the C<:status> tag from
+L<Qmail::Deliverable::Status>. Loading them does not pull in any of
+C<Qmail::Deliverable>'s privileged code:
+
+    use Qmail::Deliverable::Client qw(deliverable :status);
+
+    my $rv = deliverable $address;
+    warn "daemon down" if $rv == QD_CLIENT_FAILURE;
 
 =head1 PERFORMANCE
 

--- a/lib/Qmail/Deliverable/Status.pm
+++ b/lib/Qmail/Deliverable/Status.pm
@@ -4,7 +4,7 @@ use strict;
 use 5.006;
 use Exporter 'import';
 
-our $VERSION = '1.10';
+our $VERSION = '1.11';
 
 use constant {
     QD_NOT_DELIVERABLE         => 0x00,

--- a/lib/Qmail/Deliverable/Status.pm
+++ b/lib/Qmail/Deliverable/Status.pm
@@ -1,0 +1,160 @@
+package Qmail::Deliverable::Status;
+
+use strict;
+use 5.006;
+use Exporter 'import';
+
+our $VERSION = '1.10';
+
+use constant {
+    QD_NOT_DELIVERABLE         => 0x00,
+    QD_UNKNOWN_PERM_DENIED     => 0x11,
+    QD_UNKNOWN_PIPE            => 0x12,
+    QD_UNKNOWN_BOUNCESAYING    => 0x13,
+    QD_EZMLM                   => 0x14,
+    QD_TEMPFAIL_GROUP_WRITABLE => 0x21,
+    QD_TEMPFAIL_STICKY         => 0x22,
+    QD_CLIENT_FAILURE          => 0x2f,
+    QD_DELIVERABLE             => 0xf1,
+    QD_VPOPMAIL_DIR            => 0xf2,
+    QD_VPOPMAIL_VALIAS         => 0xf3,
+    QD_VPOPMAIL_CATCHALL       => 0xf4,
+    QD_VPOPMAIL_VUSER          => 0xf5,
+    QD_VPOPMAIL_QMAIL_EXT      => 0xf6,
+    QD_VPOPMAIL_NO_DOMAIN      => 0xfe,
+    QD_NOT_LOCAL               => 0xff,
+};
+
+our @STATUS = qw(
+    QD_NOT_DELIVERABLE
+    QD_UNKNOWN_PERM_DENIED
+    QD_UNKNOWN_PIPE
+    QD_UNKNOWN_BOUNCESAYING
+    QD_EZMLM
+    QD_TEMPFAIL_GROUP_WRITABLE
+    QD_TEMPFAIL_STICKY
+    QD_CLIENT_FAILURE
+    QD_DELIVERABLE
+    QD_VPOPMAIL_DIR
+    QD_VPOPMAIL_VALIAS
+    QD_VPOPMAIL_CATCHALL
+    QD_VPOPMAIL_VUSER
+    QD_VPOPMAIL_QMAIL_EXT
+    QD_VPOPMAIL_NO_DOMAIN
+    QD_NOT_LOCAL
+);
+
+our @EXPORT_OK = @STATUS;
+our %EXPORT_TAGS = (
+    all    => \@STATUS,
+    status => \@STATUS,
+);
+
+1;
+
+__END__
+
+=head1 NAME
+
+Qmail::Deliverable::Status - Status-code constants for Qmail::Deliverable
+
+=head1 SYNOPSIS
+
+    use Qmail::Deliverable::Status qw(:all);
+
+    if ($rv == QD_DELIVERABLE)        { ... }
+    if ($rv == QD_NOT_LOCAL)          { ... }
+    if ($rv == QD_VPOPMAIL_CATCHALL)  { ... }
+
+=head1 DESCRIPTION
+
+Symbolic names for the integer status codes returned by
+L<Qmail::Deliverable/deliverable> and
+L<Qmail::Deliverable::Client/deliverable>. The numeric values are unchanged
+from earlier releases; the constants exist purely for readability.
+
+Loading this module has no side effects, which makes it safe to import
+into unprivileged code that does not want to pull in the rest of
+L<Qmail::Deliverable> (which reads C</var/qmail/control/*> at load time).
+
+=head1 CONSTANTS
+
+=over 4
+
+=item C<QD_NOT_DELIVERABLE> (0x00)
+
+The address is not deliverable.
+
+=item C<QD_UNKNOWN_PERM_DENIED> (0x11)
+
+Deliverability could not be determined because of file permissions.
+
+=item C<QD_UNKNOWN_PIPE> (0x12)
+
+A C<|>-command appears in the dot-qmail file.
+
+=item C<QD_UNKNOWN_BOUNCESAYING> (0x13)
+
+A C<bouncesaying> directive with extra program arguments.
+
+=item C<QD_EZMLM> (0x14)
+
+Probably deliverable: looks like an ezmlm mailing list.
+
+=item C<QD_TEMPFAIL_GROUP_WRITABLE> (0x21)
+
+Temporarily undeliverable: the home directory is group- or world-writable.
+
+=item C<QD_TEMPFAIL_STICKY> (0x22)
+
+Temporarily undeliverable: the home directory has the sticky bit set.
+
+=item C<QD_CLIENT_FAILURE> (0x2f)
+
+Returned only by L<Qmail::Deliverable::Client>; indicates the daemon could
+not be reached.
+
+=item C<QD_DELIVERABLE> (0xf1)
+
+Deliverable, almost certainly: bare C<.qmail> or normal forwarding.
+
+=item C<QD_VPOPMAIL_DIR> (0xf2)
+
+Deliverable via vpopmail: a directory named after the local part exists.
+
+=item C<QD_VPOPMAIL_VALIAS> (0xf3)
+
+Deliverable via vpopmail: a C<valias> entry exists.
+
+=item C<QD_VPOPMAIL_CATCHALL> (0xf4)
+
+Deliverable via vpopmail: catch-all forwarding configured.
+
+=item C<QD_VPOPMAIL_VUSER> (0xf5)
+
+Deliverable via vpopmail: a virtual user exists.
+
+=item C<QD_VPOPMAIL_QMAIL_EXT> (0xf6)
+
+Deliverable via vpopmail: matched the C<qmail-ext> probe.
+
+=item C<QD_VPOPMAIL_NO_DOMAIN> (0xfe)
+
+vpopmail (vdelivermail) was detected but no domain was given in the address.
+
+=item C<QD_NOT_LOCAL> (0xff)
+
+The domain is not local.
+
+=back
+
+=head1 EXPORTS
+
+Nothing by default. Pass C<:all> or C<:status> to import every constant,
+or list individual ones explicitly.
+
+=head1 SEE ALSO
+
+L<Qmail::Deliverable>, L<Qmail::Deliverable::Client>
+
+=cut

--- a/t/00.syntax.t
+++ b/t/00.syntax.t
@@ -19,5 +19,6 @@ foreach my $glob ( @moduleGlobs ) {
 use lib 'lib';
 use_ok('Qmail::Deliverable');
 use_ok('Qmail::Deliverable::Client');
+use_ok('Qmail::Deliverable::Status');
 
 done_testing();

--- a/t/15.constants.t
+++ b/t/15.constants.t
@@ -1,0 +1,88 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib 'lib';
+
+# Numeric values for each constant — these are the documented status codes
+# and they must NEVER change without a major-version bump, since the daemon
+# wire format and the qpsmtpd plugin both depend on the exact integers.
+my %expected = (
+    QD_NOT_DELIVERABLE         => 0x00,
+    QD_UNKNOWN_PERM_DENIED     => 0x11,
+    QD_UNKNOWN_PIPE            => 0x12,
+    QD_UNKNOWN_BOUNCESAYING    => 0x13,
+    QD_EZMLM                   => 0x14,
+    QD_TEMPFAIL_GROUP_WRITABLE => 0x21,
+    QD_TEMPFAIL_STICKY         => 0x22,
+    QD_CLIENT_FAILURE          => 0x2f,
+    QD_DELIVERABLE             => 0xf1,
+    QD_VPOPMAIL_DIR            => 0xf2,
+    QD_VPOPMAIL_VALIAS         => 0xf3,
+    QD_VPOPMAIL_CATCHALL       => 0xf4,
+    QD_VPOPMAIL_VUSER          => 0xf5,
+    QD_VPOPMAIL_QMAIL_EXT      => 0xf6,
+    QD_VPOPMAIL_NO_DOMAIN      => 0xfe,
+    QD_NOT_LOCAL               => 0xff,
+);
+
+subtest 'Qmail::Deliverable::Status defines and exports the documented constants' => sub {
+    require Qmail::Deliverable::Status;
+    Qmail::Deliverable::Status->import(':all');
+    for my $name (sort keys %expected) {
+        no strict 'refs';
+        is __PACKAGE__->can($name)->(),
+           $expected{$name},
+           "$name = " . sprintf('0x%02x', $expected{$name});
+    }
+};
+
+subtest 'Qmail::Deliverable re-exports under :status' => sub {
+    package T1;
+    use Test::More;
+    use Qmail::Deliverable qw(:status);
+
+    for my $name (sort keys %expected) {
+        no strict 'refs';
+        is __PACKAGE__->can($name)->(),
+           $expected{$name},
+           "$name imported from Qmail::Deliverable :status";
+    }
+};
+
+subtest 'Qmail::Deliverable :all includes the status constants' => sub {
+    package T2;
+    use Test::More;
+    use Qmail::Deliverable qw(:all);
+
+    is QD_DELIVERABLE(), 0xf1, ':all imports QD_DELIVERABLE';
+    is QD_NOT_LOCAL(),   0xff, ':all imports QD_NOT_LOCAL';
+    # And the original functions are still exported
+    ok __PACKAGE__->can('deliverable'),  ':all still exports deliverable()';
+    ok __PACKAGE__->can('qmail_local'),  ':all still exports qmail_local()';
+};
+
+subtest 'Qmail::Deliverable::Client re-exports under :status' => sub {
+    package T3;
+    use Test::More;
+    use Qmail::Deliverable::Client qw(:status);
+
+    is QD_CLIENT_FAILURE(), 0x2f, 'Client exports QD_CLIENT_FAILURE';
+    is QD_NOT_LOCAL(),      0xff, 'Client exports QD_NOT_LOCAL';
+};
+
+subtest 'Loading ::Status is side-effect free' => sub {
+    # If Qmail::Deliverable::Status accidentally pulled in
+    # Qmail::Deliverable, the latter would try to reread_config() against
+    # /var/qmail at load time. Verify that doesn't happen by checking %INC.
+    delete $INC{'Qmail/Deliverable.pm'};
+    delete $INC{'Qmail/Deliverable/Status.pm'};
+
+    require Qmail::Deliverable::Status;
+    ok exists $INC{'Qmail/Deliverable/Status.pm'},
+       'Status module loaded';
+    ok !exists $INC{'Qmail/Deliverable.pm'},
+       'Loading Status did not drag in Qmail::Deliverable';
+};
+
+done_testing();

--- a/t/50.deliverable.t
+++ b/t/50.deliverable.t
@@ -40,14 +40,10 @@ subtest '0x21 - group-writable homedir' => sub {
        'homedir mode 0775 yields 0x21';
 };
 
-subtest '0x22 vs 0xf1 - "sticky" path is unreachable on a directory' => sub {
-    # The implementation uses `-T _` (text-file test) where the comment says
-    # "sticky". `-T` on a directory returns undef on every platform we know
-    # of, so 0x22 is never reached and we fall through to 0xf1 via
-    # defaultdelivery (no bare .qmail).
+subtest '0x22 - sticky homedir' => sub {
     is sprintf('0x%02x', deliverable('sticky@sub.example.com')),
-       '0xf1',
-       'mode 1755 homedir does NOT yield 0x22; falls through';
+       '0x22',
+       'mode 1755 homedir yields 0x22 (sticky bit detected)';
 };
 
 SKIP: {

--- a/t/65.daemon_signals.t
+++ b/t/65.daemon_signals.t
@@ -3,7 +3,6 @@ use warnings;
 use Test::More;
 use File::Temp qw(tempdir);
 use POSIX ":sys_wait_h";
-use IO::Socket::INET;
 
 use lib 'lib';
 use lib 't/lib';

--- a/t/65.daemon_signals.t
+++ b/t/65.daemon_signals.t
@@ -1,0 +1,103 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempdir);
+use POSIX ":sys_wait_h";
+use IO::Socket::INET;
+
+use lib 'lib';
+use lib 't/lib';
+
+use Qmail::Deliverable;
+use QDTest qw(setup_abs_fixtures start_daemon stop_daemon);
+
+my $fixtures = setup_abs_fixtures();
+
+subtest 'pidfile is created with correct PID and removed on SIGTERM' => sub {
+    my $tmp = tempdir(CLEANUP => 1);
+    my $pidfile = "$tmp/qd.pid";
+    my ($pid, $port) = start_daemon(
+        qmail_dir => $fixtures,
+        pidfile   => $pidfile,
+    );
+
+    ok -e $pidfile, 'pidfile exists after start';
+
+    open my $fh, '<', $pidfile or die "open $pidfile: $!";
+    my $written_pid = do { local $/; <$fh> };
+    close $fh;
+    chomp $written_pid;
+    is $written_pid, $pid, 'pidfile contains the daemon PID';
+
+    stop_daemon($pid);
+
+    ok !-e $pidfile, 'pidfile removed on shutdown';
+};
+
+subtest 'SIGINT also triggers clean shutdown + pidfile cleanup' => sub {
+    my $tmp = tempdir(CLEANUP => 1);
+    my $pidfile = "$tmp/qd.pid";
+    my ($pid, $port) = start_daemon(
+        qmail_dir => $fixtures,
+        pidfile   => $pidfile,
+    );
+
+    ok -e $pidfile, 'pidfile exists';
+
+    # Send SIGINT and wait for the child to exit.
+    {
+        local $?;
+        kill 'INT', $pid;
+        my $deadline = time + 5;
+        while (time < $deadline) {
+            my $r = waitpid $pid, WNOHANG;
+            last if $r == $pid;
+            select undef, undef, undef, 0.05;
+        }
+    }
+
+    ok !kill(0, $pid), 'daemon process has exited';
+    ok !-e $pidfile, 'pidfile removed after SIGINT';
+};
+
+subtest 'no pidfile written when --pidfile is not given' => sub {
+    my $tmp = tempdir(CLEANUP => 1);
+    my ($pid, $port) = start_daemon(qmail_dir => $fixtures);
+
+    opendir my $dh, $tmp or die $!;
+    my @entries = grep !/^\.\.?$/, readdir $dh;
+    closedir $dh;
+    is scalar @entries, 0,
+       'no stray files appear in the tempdir without --pidfile';
+
+    stop_daemon($pid);
+};
+
+subtest 'startup failure leaves no pidfile behind' => sub {
+    my $tmp = tempdir(CLEANUP => 1);
+    my $pidfile = "$tmp/qd.pid";
+
+    # Run a first daemon that occupies a known port.
+    my ($pid1, $port) = start_daemon(qmail_dir => $fixtures);
+
+    # Try to start a second daemon on the same port -- bind will fail
+    # before pidfile is opened, so no pidfile should be left.
+    my $child = fork;
+    die "fork: $!" if not defined $child;
+    if ($child == 0) {
+        @ARGV = ('--foreground', '--listen', "127.0.0.1:$port",
+                 '--pidfile', $pidfile);
+        $Qmail::Deliverable::qmail_dir = $fixtures;
+        Qmail::Deliverable::reread_config();
+        my $bin = QDTest::repo_root() . '/bin/qmail-deliverabled';
+        do $bin;
+        exit 1;
+    }
+    waitpid $child, 0;
+    ok !-e $pidfile,
+       'failed startup (port in use) does not leave an orphan pidfile';
+
+    stop_daemon($pid1);
+};
+
+done_testing();

--- a/t/lib/QDTest.pm
+++ b/t/lib/QDTest.pm
@@ -86,6 +86,7 @@ sub setup_perm_dirs {
 sub start_daemon {
     my (%opts) = @_;
     my $qmail_dir = $opts{qmail_dir} or die "qmail_dir required";
+    my $pidfile   = $opts{pidfile};   # optional
     my $root      = repo_root();
 
     for my $attempt (1 .. 5) {
@@ -95,6 +96,7 @@ sub start_daemon {
 
         if ($pid == 0) {
             @ARGV = ('--foreground', '--listen', "127.0.0.1:$port");
+            push @ARGV, '--pidfile', $pidfile if $pidfile;
             $Qmail::Deliverable::qmail_dir = $qmail_dir;
             Qmail::Deliverable::reread_config();
             do "$root/bin/qmail-deliverabled";


### PR DESCRIPTION
## Summary

- new: `Status` module exporting symbolic constants (`QD_DELIVERABLE`, ...) for the 16 status codes
- fix: sticky-bit homedir check (status `0x22`) used `-T _`  where it should have been `-k _`; the check is now reachable
- change: `qmail-deliverabled` now performs proper daemonization with `POSIX::setsid`; binds the listen socket before forking so port-bind errors are visible
- change: `qmail-deliverabled` installs SIGTERM/SIGINT handlers for clean shutdown, removes the pidfile on exit
- change: `qmail-deliverabled` ignores SIGPIPE so a broken client mid-response does not kill the daemon
- change: removed the deprecated old-style positional argv parsing in `qmail-deliverabled` (deprecated since 1.04, ~2007)

## Type of change

- [x] Bug fix
- [x] Refactor / cleanup

## Testing

- [x] tested against test suite
- [ ] tested on live server